### PR TITLE
Partially solved regression introduced in last commit. 

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -47,10 +47,14 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
     top_build_dir = build_dir
     # Only gems included AFTER the mruby-require gem during compilation are 
     # compiled as separate objects.
-    @bundled = gems.drop_while {|b| b.name != "mruby-require"}
-    @bundled.reject! {|b| b.name == 'mruby-require'}
-    gems.reject! {|g| @bundled.find {|b| b.name == g.name}}
+    gems_uniq   = gems.uniq {|x| x.name}
+    mr_position = gems_uniq.find_index {|g| g.name == "mruby-require"}
+    compiled_in = gems_uniq[0..mr_position].map {|g| g.name}
+    @bundled    = gems_uniq.reject {|g| compiled_in.include?(g.name) or g.name == 'mruby-require'}
+    gems.reject! {|g| !compiled_in.include?(g.name)}
+
     @bundled.each do |g|
+      g.setup
       next if g.objs.nil? or g.objs.empty?
       ENV["MRUBY_REQUIRE"] += "#{g.name},"
       sharedlib = "#{top_build_dir}/lib/#{g.name}.so"


### PR DESCRIPTION
I am deeply sorry, but my latest pull request was flawed. The fact is that the `g.objs` field is only created AFTER the loading of all the gems, so my previous solution did never actually compile the requested libraries.

This new PR fixes this by forcing a call to `g.setup` within the `each` loop, so that the list of object files is known annd the bundled gems are actually compiled. This solution works as expected: gems required in setup after the mruby-require gem itself are compiled as shared object files, those appearing before are compiled into the libmruby library.

There is still an issue, though, for which I'd like to discuss the better implementation: when another gem depends on a system-level dynamic library (e.g. `pcre`), when linking any one of the gems appearing after the mruby-require the linker fails, because the libmruby.a depends on a dll, which does not appear on the linker command line (as `-lpcre`).

Any idea on how to fix this? we could track all the external libs required by other gems by calling the `setup` method for each gem, and then accumulating all the dependencies into an array for using it when calling the linker. But it seems cumbersome to me.
