### PR TITLE
Non ext file load as '.rb'

### DIFF
--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -423,10 +423,10 @@ load_file(mrb_state *mrb, mrb_value filepath)
 {
   char *ext = strrchr(RSTRING_PTR(filepath), '.');
 
-  if (strcmp(ext, ".mrb") == 0) {
-    load_mrb_file(mrb, filepath);
-  } else if (strcmp(ext, ".rb") == 0) {
+  if (!ext || strcmp(ext, ".rb") == 0) {
     load_rb_file(mrb, filepath);
+  } else if (strcmp(ext, ".mrb") == 0) {
+    load_mrb_file(mrb, filepath);
   } else if (strcmp(ext, ".so") == 0) {
     load_so_file(mrb, filepath);
   } else {


### PR DESCRIPTION
Current, Can't load file that nothing ext filename.
I think, It's should be load same as '.rb'.

```
load '/tmp/foo'
#=> segmentation fault
```

(OS: Mac OS X)
(mruby: d3fda42eb62b4132eb91fb75acc28d3218415c8b)
