### PR TITLE
Also accept dylib and dll as compiled library extensions

### DIFF
--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -434,7 +434,9 @@ load_file(mrb_state *mrb, mrb_value filepath)
     load_rb_file(mrb, filepath);
   } else if (strcmp(ext, ".mrb") == 0) {
     load_mrb_file(mrb, filepath);
-  } else if (strcmp(ext, ".so") == 0 || strcmp(ext, ".dll") == 0) {
+  } else if (strcmp(ext, ".so") == 0 || 
+             strcmp(ext, ".dll") == 0 || 
+             strcmp(ext, ".dylib") == 0) {
     load_so_file(mrb, filepath);
   } else {
     mrb_raisef(mrb, E_LOAD_ERROR, "Filepath '%S' has invalid extension.", filepath);

--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -434,7 +434,7 @@ load_file(mrb_state *mrb, mrb_value filepath)
     load_rb_file(mrb, filepath);
   } else if (strcmp(ext, ".mrb") == 0) {
     load_mrb_file(mrb, filepath);
-  } else if (strcmp(ext, ".so") == 0) {
+  } else if (strcmp(ext, ".so") == 0 || strcmp(ext, ".dll") == 0) {
     load_so_file(mrb, filepath);
   } else {
     mrb_raisef(mrb, E_LOAD_ERROR, "Filepath '%S' has invalid extension.", filepath);


### PR DESCRIPTION
Beside linux-ish `.so` extension, also accept `.dylib` (Mac) and `.dll` (Win) extensions.