### PR TITLE
Don't set to $0

### DIFF
--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -418,7 +418,6 @@ load_rb_file(mrb_state *mrb, mrb_value filepath)
 
   file = fopen((const char*)fpath, "r");
   mrbc_filename(mrb, mrbc_ctx, fpath);
-  mrb_gv_set(mrb, mrb_intern(mrb, "$0", 2), filepath);
   mrb_load_file_cxt(mrb, file, mrbc_ctx);
   fclose(file);
 


### PR DESCRIPTION
I'm using to https://github.com/ongaeshi/RubyPico (mruby-require is working on iOS!)

Sample code.

**r1.rb**
```ruby
require './r2'

puts "-- r1 --"
puts "__FILE__: #{__FILE__}"
puts "$0: #{$0}"

if __FILE__ == $0
  def main
    puts "-- r2 --"
    f
  end
end
```

**r2.rb**
```ruby
def f
  puts "__FILE__: #{__FILE__}"
  puts "$0: #{$0}"
end

if __FILE__ == $0
  def main
    f
  end
end
```

I want to this.

- r1.rb#main is called when run r1.rb
- r2.rb#main is called when run r2.rb

Therefore, I do not want to set a $ 0 when require and load.
$0 is set in the application when user starts the script.

