### PR TITLE
Try load as .rb file like CRuby

### DIFF
--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -456,8 +456,7 @@ load_file(mrb_state *mrb, mrb_value filepath)
              strcmp(ext, ".dylib") == 0) {
     load_so_file(mrb, filepath);
   } else {
-    mrb_raisef(mrb, E_LOAD_ERROR, "Filepath '%S' has invalid extension.", filepath);
-    return;
+    load_rb_file(mrb, filepath);
   }
 }
 


### PR DESCRIPTION
CRuby's `Kernel#load` try to load as .rb any file.

```
$ irb
irb(main):001:0> load 'README.md'
README.md:3: syntax error, unexpected tCONSTANT, expecting keyword_do or '{' or '('
[![Build Status](https://travis-ci.org/mattn...
               ^
SyntaxError: compile error
	from (irb):1:in `load'
	from (irb):1
	from /Users/yuki/.rbenv/versions/2.4.0-dev/bin/irb:11:in `<main>'
```

We might as well support this behavior.