### PR TITLE
Raise detailed exception when SyntaxError occurs in requring ruby source file.

### DIFF
--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -437,6 +437,7 @@ load_rb_file(mrb_state *mrb, mrb_value filepath)
   }
 
   mrbc_ctx = mrbc_context_new(mrb);
+  mrbc_ctx->capture_errors = 1;
 
   mrbc_filename(mrb, mrbc_ctx, fpath);
   mrb_load_file_cxt(mrb, fp, mrbc_ctx);

--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -15,6 +15,7 @@
 #include "mruby/numeric.h"
 
 #include "opcode.h"
+//#include <mruby/opcode.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
@@ -442,6 +443,19 @@ load_rb_file(mrb_state *mrb, mrb_value filepath)
   mrbc_filename(mrb, mrbc_ctx, fpath);
   mrb_load_file_cxt(mrb, fp, mrbc_ctx);
   fclose(fp);
+
+  if(mrb->exc) {
+    mrb_value exc_obj = mrb_obj_value(mrb->exc);
+    mrb_value err_message = mrb_funcall(mrb, exc_obj, "inspect", 0);
+    const char *err = RSTRING_PTR(err_message);
+    struct RClass *exc_class = mrb_obj_class(mrb, exc_obj);
+    if(!exc_class)
+      exc_class = mrb->eException_class;
+    mrb_gc_arena_restore(mrb, ai);
+    mrbc_context_free(mrb, mrbc_ctx);
+    mrb_raisef(mrb, exc_class,"In %s: %s", fpath, err);
+    return;
+  }
 
   mrb_gc_arena_restore(mrb, ai);
   mrbc_context_free(mrb, mrbc_ctx);


### PR DESCRIPTION
  Hello, It was a problem that when requring a ruby source file within syntax error in another ruby source file, mrb->exc could not give detailed information about it(Though when parsing ruby source file with syntax error, yylex will print the detailed information of that syntax error to stderr, but if you embed mruby to an application without a console window, you would not see it). So I modified your 'load_rb_file' function and managed to store syntax-error information to mrb->exc. This is the main purpose of this pull request.  