### PR TITLE
Update for mruby 3.x

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -116,10 +116,12 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
   end
 
   spec.cc.include_paths << ["#{MRUBY_ROOT}/src"]
-  if RUBY_PLATFORM.downcase !~ /mswin(?!ce)|mingw|bccwin/
-    spec.linker.libraries << ['dl']
-    spec.cc.flags << "-DMRBGEMS_ROOT=\\\"#{File.expand_path top_build_dir}/lib\\\""
-  else
-    spec.cc.flags << "-DMRBGEMS_ROOT=\"\"\\\"#{File.expand_path top_build_dir}/lib\\\"\"\""
+  unless spec.cc.flags.flatten.find {|e| e.match /DMRBGEMS_ROOT/}
+    if RUBY_PLATFORM.downcase !~ /mswin(?!ce)|mingw|bccwin/
+      spec.linker.libraries << ['dl']
+      spec.cc.flags << "-DMRBGEMS_ROOT=\\\"#{File.expand_path top_build_dir}/lib\\\""
+    else
+      spec.cc.flags << "-DMRBGEMS_ROOT=\"\"\\\"#{File.expand_path top_build_dir}/lib\\\"\"\""
+    end
   end
 end

--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -13,6 +13,8 @@
 #include "mruby/variable.h"
 #include "mruby/array.h"
 #include "mruby/numeric.h"
+#include "mruby/internal.h"
+#include "mruby/irep.h"
 
 #include "opcode.h"
 #include <stdio.h>


### PR DESCRIPTION
Mostly, now the headers `internal.h` and `rep.h` must be explicitly included.