### PR TITLE
No need for `mruby/internal.h` file

### DIFF
--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -13,7 +13,6 @@
 #include "mruby/variable.h"
 #include "mruby/array.h"
 #include "mruby/numeric.h"
-#include "mruby/internal.h"
 #include "mruby/irep.h"
 
 #include "opcode.h"


### PR DESCRIPTION
As of the mruby 3.2 release, it is no longer necessary to `mruby/internal.h` in order to use `mrb_proc_new()` and `mrb_read_irep_file()`.