### PR TITLE
Include the `mruby/include/mruby/opcode.h` file

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -119,7 +119,6 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
     end
   end
 
-  spec.cc.include_paths << ["#{MRUBY_ROOT}/src"]
   unless spec.cc.flags.flatten.find {|e| e.match /DMRBGEMS_ROOT/}
     if RUBY_PLATFORM.downcase !~ /mswin(?!ce)|mingw|bccwin/
       spec.linker.libraries << ['dl']

--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -14,8 +14,8 @@
 #include "mruby/array.h"
 #include "mruby/numeric.h"
 #include "mruby/irep.h"
+#include "mruby/opcode.h"
 
-#include "opcode.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>


### PR DESCRIPTION
The `mruby/src/opcode.h` file says, "this header file is to be removed soon.".