### PR TITLE
Allow switching between fibers inside `load/require`

### DIFF
--- a/.github/workflows/testrun.yml
+++ b/.github/workflows/testrun.yml
@@ -22,14 +22,20 @@ jobs:
     env:
       MRUBY_URL: "https://github.com/mruby/mruby/archive/${{ matrix.TARGET_MRUBY }}.tar.gz"
       MRUBY_DIR: "mruby-${{ matrix.TARGET_MRUBY }}"
-      MRUBY_CONFIG: "run_test.rb"
+      MRUBY_CONFIG: "../run_test.rb"
     steps:
     - uses: actions/checkout@v3
     - name: fetch and extract mruby
       run: wget -O- $MRUBY_URL | tar xzf -
     - name: pre-clean
-      run: rake -vf $MRUBY_DIR/Rakefile clean
+      run: |
+        cd $MRUBY_DIR
+        rake -v clean
     - name: build
-      run: rake -mvf $MRUBY_DIR/Rakefile test:build || rake -mvf $MRUBY_DIR/Rakefile || rake -vf $MRUBY_DIR/Rakefile
+      run: |
+        cd $MRUBY_DIR
+        rake -mv test:build || rake -mv || rake -v
     - name: test
-      run: rake -vf $MRUBY_DIR/Rakefile test
+      run: |
+        cd $MRUBY_DIR
+        rake -v test

--- a/bintest/require-test.rb
+++ b/bintest/require-test.rb
@@ -1,0 +1,47 @@
+def assert_mruby_require(expect, code)
+  env = { "MRBLIB" => File.dirname(__dir__) }
+  cmd = [cmd("mruby"), "-e", code]
+  result = IO.popen(env, cmd, "r", err: [:child, :out]) { |pipe| pipe.read }
+  diff = "    Expected #{result.inspect} to be match to #{expect.inspect}."
+  cond = expect === result
+  assert_true cond, nil, diff
+end
+
+unused = 1 # variables to check for invisibility in `require/load`
+
+assert "require" do
+  assert_mruby_require <<~'RESULT', %(3.times { p require "testfiles/minimal" })
+    {:self=>main}
+    {:instance_variables=>[]}
+    {:module=>A}
+    true
+    false
+    false
+  RESULT
+
+  assert_mruby_require /\(LoadError\)$/, %(require "testfiles/notexist")
+end
+
+assert "require with fiber" do
+  assert_mruby_require /\[0, 3, 6\]\n.* \(FiberError\)$/m, %(require "testfiles/fiber")
+end
+
+assert "load" do
+  assert_mruby_require <<~'RESULT', %(3.times { p load "testfiles/minimal.rb" })
+    {:self=>main}
+    {:instance_variables=>[]}
+    {:module=>A}
+    true
+    {:self=>main}
+    {:instance_variables=>[]}
+    {:module=>A}
+    true
+    {:self=>main}
+    {:instance_variables=>[]}
+    {:module=>A}
+    true
+  RESULT
+
+  assert_mruby_require /\(LoadError\)$/, %(load "testfiles/minimal") # because it does not complement the extensions
+  assert_mruby_require /\(LoadError\)$/, %(load "testfiles/notexist.rb")
+end

--- a/bintest/require-test.rb
+++ b/bintest/require-test.rb
@@ -45,3 +45,11 @@ assert "load" do
   assert_mruby_require /\(LoadError\)$/, %(load "testfiles/minimal") # because it does not complement the extensions
   assert_mruby_require /\(LoadError\)$/, %(load "testfiles/notexist.rb")
 end
+
+assert "load with wrapper" do
+  assert_mruby_require /\{:self=>main\}\n\{:instance_variables=>\[\]\}\n\{:module=>A\}\n/, %(load "testfiles/minimal.rb", nil)
+  assert_mruby_require /\{:self=>main\}\n\{:instance_variables=>\[\]\}\n\{:module=>A\}\n/, %(load "testfiles/minimal.rb", false)
+  assert_mruby_require /\{:self=>main\}\n\{:instance_variables=>\[\]\}\n\{:module=>#<Module:0x\w+>::A\}\n/, %(load "testfiles/minimal.rb", true)
+  assert_mruby_require /\{:self=>main\}\n\{:instance_variables=>\[\]\}\n\{:module=>#<Module:0x\w+>::A\}\n/, %(load "testfiles/minimal.rb", Object)
+  assert_mruby_require /\{:self=>main\}\n\{:instance_variables=>\[\]\}\n\{:module=>Kernel::A\}\n/, %(load "testfiles/minimal.rb", Kernel)
+end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -38,6 +38,8 @@ end
 MRuby::Gem::Specification.new('mruby-require') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
+  spec.add_test_dependency "mruby-bin-mruby", core: "mruby-bin-mruby"
+
   ENV["MRUBY_REQUIRE"] = ""
 
   is_vc = ENV['OS'] == 'Windows_NT' && cc.command =~ /^cl(\.exe)?$/

--- a/mrblib/require.rb
+++ b/mrblib/require.rb
@@ -1,0 +1,41 @@
+loading_path = []
+runner = ->(lib, path) do
+  unless path
+    instance_eval(&lib)
+    true
+  else
+    return false if loading_path.include?(path)
+    loading_path << path
+
+    begin
+      instance_eval(&lib)
+      $" << path
+      true
+    ensure
+      loading_path.pop rescue nil
+    end
+  end
+end
+
+Kernel.define_method(:require, &->(path) {
+  lib, path = Kernel.__require_load_library(path, true, nil)
+  if path
+    runner.call(lib, path)
+  else
+    lib # true or false
+  end
+})
+
+Kernel.define_method(:load, &->(path, wrap = false) {
+  case
+  when !wrap
+    wrap = nil
+  when wrap.kind_of?(Module) && !wrap.kind_of?(Class)
+    # use module as is
+  else
+    wrap = Module.new
+  end
+
+  lib, path = Kernel.__require_load_library(path, false, wrap)
+  runner.call(lib, nil)
+})

--- a/run_test.rb
+++ b/run_test.rb
@@ -15,6 +15,7 @@ MRuby::Build.new do |conf|
   toolchain :clang
   conf.enable_debug
   conf.enable_test
+  conf.enable_bintest
   conf.cc.flags << ["-fPIC"]
   conf.gembox 'default'
   conf.gem File.dirname(File.expand_path(__FILE__))

--- a/src/mrb_require.c
+++ b/src/mrb_require.c
@@ -15,6 +15,7 @@
 #include "mruby/numeric.h"
 #include "mruby/irep.h"
 #include "mruby/opcode.h"
+#include "mruby/class.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -261,8 +262,8 @@ replace_stop_with_return(mrb_state *mrb, mrb_irep *irep)
 }
 #endif
 
-static void
-load_mrb_file(mrb_state *mrb, mrb_value filepath)
+static mrb_value
+load_mrb_file(mrb_state *mrb, mrb_value filepath, struct RClass *wrap)
 {
   const char *fpath = RSTRING_CSTR(mrb, filepath);
   int ai;
@@ -276,7 +277,7 @@ load_mrb_file(mrb_state *mrb, mrb_value filepath)
       mrb_str_new_cstr(mrb, fpath),
       "cannot load such file"
     );
-    return;
+    return mrb_nil_value(); // not reached
   }
 
   ai = mrb_gc_arena_save(mrb);
@@ -299,15 +300,16 @@ load_mrb_file(mrb_state *mrb, mrb_value filepath)
     replace_stop_with_return(mrb, irep);
 #endif
     proc = mrb_proc_new(mrb, irep);
-    MRB_PROC_SET_TARGET_CLASS(proc, mrb->object_class);
+    MRB_PROC_SET_TARGET_CLASS(proc, wrap);
+    proc->flags |= MRB_PROC_SCOPE;
 
-    ai = mrb_gc_arena_save(mrb);
-    mrb_yield_with_class(mrb, mrb_obj_value(proc), 0, NULL, mrb_top_self(mrb), mrb->object_class);
-    mrb_gc_arena_restore(mrb, ai);
+    return mrb_obj_value(proc);
   } else if (mrb->exc) {
     // fail to load
     mrb_exc_raise(mrb, mrb_obj_value(mrb->exc));
   }
+
+  return mrb_nil_value();
 }
 
 static void
@@ -336,7 +338,7 @@ mrb_load_irep_data(mrb_state* mrb, const uint8_t* data)
   }
 }
 
-static void
+static mrb_value
 load_so_file(mrb_state *mrb, mrb_value filepath)
 {
   char entry[PATH_MAX] = {0}, *ptr, *top, *tmp;
@@ -383,6 +385,8 @@ load_so_file(mrb_state *mrb, mrb_value filepath)
   if (data != NULL) {
     mrb_load_irep_data(mrb, data);
   }
+
+  return mrb_nil_value();
 }
 
 static void
@@ -421,45 +425,52 @@ unload_so_file(mrb_state *mrb, mrb_value filepath)
   fn(mrb);
 }
 
-static void
-load_rb_file(mrb_state *mrb, mrb_value filepath)
+static mrb_value
+load_rb_file(mrb_state *mrb, mrb_value filepath, struct RClass *wrap)
 {
   FILE *fp;
   const char *fpath = RSTRING_CSTR(mrb, filepath);
   mrbc_context *mrbc_ctx;
   int ai = mrb_gc_arena_save(mrb);
+  mrb_value proc;
 
   fp = fopen((const char*)fpath, "r");
   if (fp == NULL) {
     mrb_load_fail(mrb, filepath, "cannot load such file");
-    return;
+    return mrb_nil_value(); // not reached
   }
 
   mrbc_ctx = mrbc_context_new(mrb);
+  mrbc_ctx->no_exec = TRUE;
 
   mrbc_filename(mrb, mrbc_ctx, fpath);
-  mrb_load_file_cxt(mrb, fp, mrbc_ctx);
+  proc = mrb_load_file_cxt(mrb, fp, mrbc_ctx);
+  MRB_PROC_SET_TARGET_CLASS(mrb_proc_ptr(proc), wrap);
+  mrb_proc_ptr(proc)->flags |= MRB_PROC_SCOPE;
   fclose(fp);
 
   mrb_gc_arena_restore(mrb, ai);
+  mrb_gc_protect(mrb, proc);
   mrbc_context_free(mrb, mrbc_ctx);
+
+  return proc;
 }
 
-static void
-load_file(mrb_state *mrb, mrb_value filepath)
+static mrb_value
+load_file(mrb_state *mrb, mrb_value filepath, struct RClass *wrap)
 {
   char *ext = strrchr(RSTRING_CSTR(mrb, filepath), '.');
 
   if (!ext || strcmp(ext, ".rb") == 0) {
-    load_rb_file(mrb, filepath);
+    return load_rb_file(mrb, filepath, wrap);
   } else if (strcmp(ext, ".mrb") == 0) {
-    load_mrb_file(mrb, filepath);
+    return load_mrb_file(mrb, filepath, wrap);
   } else if (strcmp(ext, ".so") == 0 ||
              strcmp(ext, ".dll") == 0 ||
              strcmp(ext, ".dylib") == 0) {
-    load_so_file(mrb, filepath);
+    return load_so_file(mrb, filepath);
   } else {
-    load_rb_file(mrb, filepath);
+    return load_rb_file(mrb, filepath, wrap);
   }
 }
 
@@ -467,22 +478,8 @@ mrb_value
 mrb_load(mrb_state *mrb, mrb_value filename)
 {
   mrb_value filepath = find_file(mrb, filename, 0);
-  load_file(mrb, filepath);
+  load_file(mrb, filepath, mrb->object_class);
   return mrb_true_value(); // TODO: ??
-}
-
-mrb_value
-mrb_f_load(mrb_state *mrb, mrb_value self)
-{
-  mrb_value filename;
-
-  mrb_get_args(mrb, "o", &filename);
-  if (mrb_type(filename) != MRB_TT_STRING) {
-    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S into String", filename);
-    return mrb_nil_value();
-  }
-
-  return mrb_load(mrb, filename);
 }
 
 static int
@@ -555,7 +552,7 @@ mrb_require(mrb_state *mrb, mrb_value filename)
   mrb_value filepath = find_file(mrb, filename, 1);
   if (!mrb_nil_p(filepath) && loaded_files_check(mrb, filepath)) {
     loading_files_add(mrb, filepath);
-    load_file(mrb, filepath);
+    load_file(mrb, filepath, mrb->object_class);
     loaded_files_add(mrb, filepath);
     loading_files_delete(mrb, filepath);
     return mrb_true_value();
@@ -564,18 +561,25 @@ mrb_require(mrb_state *mrb, mrb_value filename)
   return mrb_false_value();
 }
 
-mrb_value
-mrb_f_require(mrb_state *mrb, mrb_value self)
+static mrb_value
+require_load_library(mrb_state *mrb, mrb_value self)
 {
-  mrb_value filename;
+  mrb_value filename, wrap, lib;
+  mrb_bool for_require;
 
-  mrb_get_args(mrb, "o", &filename);
+  mrb_get_args(mrb, "obo", &filename, &for_require, &wrap);
   if (mrb_type(filename) != MRB_TT_STRING) {
     mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S into String", filename);
     return mrb_nil_value();
   }
 
-  return mrb_require(mrb, filename);
+  filename = find_file(mrb, filename, (for_require ? 1 : 0));
+  if (for_require && !loaded_files_check(mrb, filename)) {
+    return mrb_false_value();
+  }
+  lib = load_file(mrb, filename, (mrb_type(wrap) == MRB_TT_MODULE ? mrb_class_ptr(wrap) : mrb->object_class));
+
+  return mrb_assoc_new(mrb, lib, (mrb_type(lib) == MRB_TT_PROC ? filename : mrb_nil_value()));
 }
 
 static mrb_value
@@ -609,8 +613,7 @@ mrb_mruby_require_gem_init(mrb_state* mrb)
   struct RClass *load_error;
   krn = mrb->kernel_module;
 
-  mrb_define_method(mrb, krn, "load",    mrb_f_load,    MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, krn, "require", mrb_f_require, MRB_ARGS_REQ(1));
+  mrb_define_class_method(mrb, krn, "__require_load_library", require_load_library, MRB_ARGS_REQ(2));
 
   load_error = mrb_define_class(mrb, "LoadError", E_SCRIPT_ERROR);
   mrb_define_method(mrb, load_error, "path", mrb_load_error_path, MRB_ARGS_NONE());

--- a/testfiles/fiber.rb
+++ b/testfiles/fiber.rb
@@ -1,0 +1,6 @@
+a = []
+fiber = Fiber.new { 3.times { |i| a << Fiber.yield(i) } }
+n = -1
+4.times { n = fiber.resume(n * 3) }
+p a
+fiber.resume(-1)

--- a/testfiles/minimal.rb
+++ b/testfiles/minimal.rb
@@ -1,0 +1,6 @@
+p self: self
+p instance_variables: instance_variables
+
+module A
+  p module: self
+end


### PR DESCRIPTION
Other points:

  - Need mruby-3.0.0 or later.
  - Support `wrap` argument for `Kernel#load`
  - Run "bintest" using `bin/mruby`.
  - Currently, I can't build the `.so` file, so I have not been able to verify the test.

- - -

https://github.com/mattn/mruby-require/issues/55#issuecomment-1519038126 の時点では、僕は C レベルでの対応を考えていました。
[実働するものはすでに実験済みだったので、移植するだけで済みますが、メンテナンス性がひどく悪いです](https://github.com/dearblue/mruby-require-concept2/blob/7e0c909f63b96e7139eef85c665e198fe2c7c35e/src/mruby-require.c#L325-L375)。
考えを改めて、https://github.com/iij/mruby-require のように Ruby での記述も併用した実装に切り替えました (コード自体はゼロから書かれたものです)。

この PR 前の状況を次に示します:

  - mruby-1.3.0 以前: ビルドエラー (`MRB_PROC_SET_TARGET_CLASS()` が必要)
  - mruby-1.4.0, 1.4.1: ビルドエラー (テストの依存ターゲットが未解決)
  - mruby-2.0.0, 2.0.1: テストに失敗 (詳細不明。プロセスが `load_file()` で終了する？)
  - mruby-2.1.0, 2.1.1: テストに失敗 (`bin/mruby` に問題あり。`mruby-require` は成功)
  - mruby-2.1.2 以降: 成功

mruby-2.1.0 以前をビルドするには、Ruby-2.7 以前が必要です。
GitHub Actions の ubuntu-22.04 は Ruby-3.0.2 なので、mruby-2.1.0 以前がビルドできませんでした。

mruby-2.1.2 は `mrblib/require.rb` ファイルの `runner` 内で `SystemStackError` が発生するようになります。

  - PR 前: https://github.com/dearblue/mruby-require-mattn/actions/runs/4889203511
  - PR 後: https://github.com/dearblue/mruby-require-mattn/actions/runs/4889231806
